### PR TITLE
feat: deprecate .forRoot() and .forChild() methods

### DIFF
--- a/projects/angular-split/src/lib/module.ts
+++ b/projects/angular-split/src/lib/module.ts
@@ -11,6 +11,7 @@ import { SplitAreaDirective } from './directive/split-area.directive'
 })
 export class AngularSplitModule {
   public static forRoot(): ModuleWithProviders<AngularSplitModule> {
+    console.warn(`AngularSplitModule.forRoot() is deprecated and will be removed in v6`)
     return {
       ngModule: AngularSplitModule,
       providers: [],
@@ -18,6 +19,7 @@ export class AngularSplitModule {
   }
 
   public static forChild(): ModuleWithProviders<AngularSplitModule> {
+    console.warn(`AngularSplitModule.forChild() is deprecated and will be removed in v6`)
     return {
       ngModule: AngularSplitModule,
       providers: [],

--- a/src/app/examples/access-from-class/access-from-class.module.ts
+++ b/src/app/examples/access-from-class/access-from-class.module.ts
@@ -9,7 +9,7 @@ import { AccessFromClassComponent } from './access-from-class.component'
   imports: [
     CommonModule,
     RouterModule.forChild([{ path: '', component: AccessFromClassComponent }]),
-    AngularSplitModule.forChild(),
+    AngularSplitModule,
     UiModule,
   ],
   declarations: [AccessFromClassComponent],

--- a/src/app/examples/collapse-expand/collapse-expand.module.ts
+++ b/src/app/examples/collapse-expand/collapse-expand.module.ts
@@ -10,7 +10,7 @@ import { CollapseExpandComponent } from './collapse-expand.component'
     CommonModule,
     UiModule,
     RouterModule.forChild([{ path: '', component: CollapseExpandComponent }]),
-    AngularSplitModule.forChild(),
+    AngularSplitModule,
   ],
   declarations: [CollapseExpandComponent],
 })

--- a/src/app/examples/custom-gutter-style/custom-gutter-style.module.ts
+++ b/src/app/examples/custom-gutter-style/custom-gutter-style.module.ts
@@ -10,7 +10,7 @@ import { CustomGutterStyleComponent } from './custom-gutter-style.component'
     CommonModule,
     UiModule,
     RouterModule.forChild([{ path: '', component: CustomGutterStyleComponent }]),
-    AngularSplitModule.forChild(),
+    AngularSplitModule,
   ],
   declarations: [CustomGutterStyleComponent],
 })

--- a/src/app/examples/dir-rtl/dir-rtl.module.ts
+++ b/src/app/examples/dir-rtl/dir-rtl.module.ts
@@ -10,7 +10,7 @@ import { DirRtlComponent } from './dir-rtl.component'
     CommonModule,
     UiModule,
     RouterModule.forChild([{ path: '', component: DirRtlComponent }]),
-    AngularSplitModule.forChild(),
+    AngularSplitModule,
   ],
   declarations: [DirRtlComponent],
 })

--- a/src/app/examples/geek-demo/geek-demo.module.ts
+++ b/src/app/examples/geek-demo/geek-demo.module.ts
@@ -11,7 +11,7 @@ import { GeekDemoComponent } from './geek-demo.component'
     CommonModule,
     UiModule,
     RouterModule.forChild([{ path: '', component: GeekDemoComponent }]),
-    AngularSplitModule.forChild(),
+    AngularSplitModule,
     FormsModule,
   ],
   declarations: [GeekDemoComponent],

--- a/src/app/examples/gutter-click-roll-unroll/gutter-click-roll-unroll.module.ts
+++ b/src/app/examples/gutter-click-roll-unroll/gutter-click-roll-unroll.module.ts
@@ -10,7 +10,7 @@ import { GutterClickRollUnrollComponent } from './gutter-click-roll-unroll.compo
     CommonModule,
     UiModule,
     RouterModule.forChild([{ path: '', component: GutterClickRollUnrollComponent }]),
-    AngularSplitModule.forChild(),
+    AngularSplitModule,
   ],
   declarations: [GutterClickRollUnrollComponent],
 })

--- a/src/app/examples/iframes/iframes.module.ts
+++ b/src/app/examples/iframes/iframes.module.ts
@@ -10,7 +10,7 @@ import { IframesComponent } from './iframes.component'
     CommonModule,
     UiModule,
     RouterModule.forChild([{ path: '', component: IframesComponent }]),
-    AngularSplitModule.forChild(),
+    AngularSplitModule,
   ],
   declarations: [IframesComponent],
 })

--- a/src/app/examples/min-max-split/min-max-split.module.ts
+++ b/src/app/examples/min-max-split/min-max-split.module.ts
@@ -8,7 +8,7 @@ import { MinMaxSplitComponent } from './min-max-split.component'
 @NgModule({
   imports: [
     CommonModule,
-    AngularSplitModule.forChild(),
+    AngularSplitModule,
     RouterModule.forChild([{ path: '', component: MinMaxSplitComponent }]),
     UiModule,
   ],

--- a/src/app/examples/nested-split/nested-split.module.ts
+++ b/src/app/examples/nested-split/nested-split.module.ts
@@ -8,7 +8,7 @@ import { NestedComponent } from './nested-split.component'
 @NgModule({
   imports: [
     CommonModule,
-    AngularSplitModule.forChild(),
+    AngularSplitModule,
     RouterModule.forChild([{ path: '', component: NestedComponent }]),
     UiModule,
   ],

--- a/src/app/examples/simple/simple.module.ts
+++ b/src/app/examples/simple/simple.module.ts
@@ -5,11 +5,7 @@ import { AngularSplitModule } from 'angular-split'
 import { SimpleComponent } from './simple.component'
 
 @NgModule({
-  imports: [
-    CommonModule,
-    RouterModule.forChild([{ path: '', component: SimpleComponent }]),
-    AngularSplitModule.forChild(),
-  ],
+  imports: [CommonModule, RouterModule.forChild([{ path: '', component: SimpleComponent }]), AngularSplitModule],
   declarations: [SimpleComponent],
 })
 export class SimpleModule {}

--- a/src/app/examples/split-transitions/split-transitions.module.ts
+++ b/src/app/examples/split-transitions/split-transitions.module.ts
@@ -10,7 +10,7 @@ import { SplitTransitionsComponent } from './split-transitions.component'
     CommonModule,
     UiModule,
     RouterModule.forChild([{ path: '', component: SplitTransitionsComponent }]),
-    AngularSplitModule.forChild(),
+    AngularSplitModule,
   ],
   declarations: [SplitTransitionsComponent],
 })

--- a/src/app/examples/sync-split/sync-split.module.ts
+++ b/src/app/examples/sync-split/sync-split.module.ts
@@ -10,7 +10,7 @@ import { SyncSplitComponent } from './sync-split.component'
     CommonModule,
     UiModule,
     RouterModule.forChild([{ path: '', component: SyncSplitComponent }]),
-    AngularSplitModule.forChild(),
+    AngularSplitModule,
   ],
   declarations: [SyncSplitComponent],
 })

--- a/src/app/examples/toggling-dom-and-visibility/toggling-dom-and-visibility.module.ts
+++ b/src/app/examples/toggling-dom-and-visibility/toggling-dom-and-visibility.module.ts
@@ -10,7 +10,7 @@ import { TogglingDomAndVisibleComponent } from './toggling-dom-and-visibility.co
     CommonModule,
     UiModule,
     RouterModule.forChild([{ path: '', component: TogglingDomAndVisibleComponent }]),
-    AngularSplitModule.forChild(),
+    AngularSplitModule,
   ],
   declarations: [TogglingDomAndVisibleComponent],
 })

--- a/src/app/examples/workspace-localstorage/workspace-localstorage.module.ts
+++ b/src/app/examples/workspace-localstorage/workspace-localstorage.module.ts
@@ -10,7 +10,7 @@ import { WorkspaceLocalstorageComponent } from './workspace-localstorage.compone
     CommonModule,
     UiModule,
     RouterModule.forChild([{ path: '', component: WorkspaceLocalstorageComponent }]),
-    AngularSplitModule.forChild(),
+    AngularSplitModule,
   ],
   declarations: [WorkspaceLocalstorageComponent],
 })

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -97,7 +97,7 @@ export class HomeComponent {
 
 @NgModule({
   imports: [
-    AngularSplitModule.forRoot(),
+    AngularSplitModule,
     ...
   ],
   ...

--- a/src/app/ui/ui.module.ts
+++ b/src/app/ui/ui.module.ts
@@ -19,7 +19,7 @@ import { TopbarComponent } from './components/topbar.component'
     BsDropdownModule.forRoot(),
     SortableModule.forRoot(),
     TooltipModule.forRoot(),
-    AngularSplitModule.forRoot(),
+    AngularSplitModule,
   ],
   declarations: [ExampleTitleComponent, TopbarComponent],
   exports: [ExampleTitleComponent, TopbarComponent, ButtonsModule, SortableModule, TooltipModule],


### PR DESCRIPTION
The `.forRoot()` and `.forChild()` methods did not add any additional options or configurations and are thus not needed.

In this PR the methods are deprecated and will show a warning, in the next major release they will be removed.