### PR TITLE
Add a delta to mouse clicks and double clicks to avoid issues where double click does not get recognized

### DIFF
--- a/projects/angular-split/src/lib/component/split.component.ts
+++ b/projects/angular-split/src/lib/component/split.component.ts
@@ -22,12 +22,13 @@ import { SplitAreaDirective } from '../directive/split-area.directive'
 import {
   getInputPositiveNumber,
   getInputBoolean,
-  isUserSizesValid,
   getAreaMinSize,
   getAreaMaxSize,
   getPointFromEvent,
   getElementPixelSize,
   getGutterSideAbsorptionCapacity,
+  isUserSizesValid,
+  pointDeltaEquals,
   updateAreaSize,
 } from '../utils'
 
@@ -181,6 +182,8 @@ export class SplitComponent implements AfterViewInit, OnDestroy {
   @Input() set gutterDblClickDuration(v: number) {
     this._gutterDblClickDuration = getInputPositiveNumber(v, 0)
   }
+
+  @Input() gutterClickDeltaPx = 2;
 
   get gutterDblClickDuration(): number {
     return this._gutterDblClickDuration
@@ -487,8 +490,7 @@ export class SplitComponent implements AfterViewInit, OnDestroy {
     // Be sure mouseup/touchend happened if touch/cursor is not moved.
     if (
       this.startPoint &&
-      this.startPoint.x === tempPoint.x &&
-      this.startPoint.y === tempPoint.y &&
+      pointDeltaEquals(this.startPoint, tempPoint, this.gutterClickDeltaPx) &&
       (!this.isDragging || this.isWaitingInitialMove)
     ) {
       // If timeout in progress and new click > clearTimeout & dblClickEvent
@@ -578,7 +580,8 @@ export class SplitComponent implements AfterViewInit, OnDestroy {
     event.preventDefault()
     event.stopPropagation()
 
-    if (this._clickTimeout !== null) {
+    const tempPoint = getPointFromEvent(event);
+    if (this._clickTimeout !== null && !pointDeltaEquals(this.startPoint, tempPoint, this.gutterClickDeltaPx)) {
       window.clearTimeout(this._clickTimeout)
       this._clickTimeout = null
     }

--- a/projects/angular-split/src/lib/utils.ts
+++ b/projects/angular-split/src/lib/utils.ts
@@ -20,6 +20,10 @@ export function getPointFromEvent(event: MouseEvent | TouchEvent): IPoint {
   return null
 }
 
+export function pointDeltaEquals(lhs: IPoint, rhs: IPoint, deltaPx: number) {
+  return Math.abs(lhs.x - rhs.x) <= deltaPx && Math.abs(lhs.y - rhs.y) <= deltaPx;
+}
+
 export function getElementPixelSize(elRef: ElementRef, direction: 'horizontal' | 'vertical'): number {
   const rect = (<HTMLElement>elRef.nativeElement).getBoundingClientRect()
 


### PR DESCRIPTION
Currently, if using an overly sensitive mouse (a magic mouse on chrome on a mac as one example), the immediate clearing of `this._clickTimeout` in `dragEvent` results in double clicks (even with a long duration, e.g. 500ms) being cleared and thus not recognized. I didn't test to see if the same is true for a single click, but based on the existing code it looks like it might be true.

To fix this, we can do a standard practice of checking for deltas to account for drags before clearing the _clickTimeout or disregarding a click on a gutter. As this delta may need to be user configurable, I've suggested it also be an input parameter with a sensible default. Personally I think the default should not be 0px (which would reflect previous state) given that some of the angular-split functionality simply does not work with some systems (magic mouse on mac as the one I know of).  Instead I suggest we start with a 2px buffer/delta in either direction (i.e. an 4px x 4px square centered on the startPoint), though if for backwards compatibility that is an issue, this can easily be resolved by setting the default to 0px.

Here's an example quickly checking SO that suggests something similar: https://stackoverflow.com/a/59741870