### PR TITLE
Documentation issue: Fix old classNames and components prefix to new one

### DIFF
--- a/src/app/documentation/documentation.component.ts
+++ b/src/app/documentation/documentation.component.ts
@@ -183,31 +183,31 @@ export class DocumentationComponent {
 
   readonly cssClasses = {
     split: [
-      { name: 'ui-init', details: 'Added after component initialization.' },
+      { name: 'as-init', details: 'Added after component initialization.' },
       {
-        name: 'ui-horizontal / ui-vertical',
-        details: 'Depends on <code>&lt;ui-split [direction]="x"&gt;</code>.',
+        name: 'as-horizontal / as-vertical',
+        details: 'Depends on <code>&lt;as-split [direction]="x"&gt;</code>.',
       },
       {
-        name: 'ui-disabled',
-        details: 'Added when <code>&lt;ui-split [disabled]="true"&gt;</code>.',
+        name: 'as-disabled',
+        details: 'Added when <code>&lt;as-split [disabled]="true"&gt;</code>.',
       },
       {
-        name: 'ui-transition',
-        details: 'Added when <code>&lt;ui-split [useTransition]="true"&gt;</code>.',
+        name: 'as-transition',
+        details: 'Added when <code>&lt;as-split [useTransition]="true"&gt;</code>.',
       },
-      { name: 'ui-dragging', details: 'Added while a gutter is dragged.' },
+      { name: 'as-dragging', details: 'Added while a gutter is dragged.' },
     ],
     area: [
-      { name: 'ui-split-area', details: 'Added on all areas.' },
+      { name: 'as-split-area', details: 'Added on all areas.' },
       {
-        name: 'ui-hidden',
-        details: 'Added when <code>&lt;ui-split-area [visible]="false"&gt;</code>.',
+        name: 'as-hidden',
+        details: 'Added when <code>&lt;as-split-area [visible]="false"&gt;</code>.',
       },
     ],
     gutter: [
-      { name: 'ui-split-gutter', details: 'Added on all gutters.' },
-      { name: 'ui-dragged', details: 'Added on gutter while dragged.' },
+      { name: 'as-split-gutter', details: 'Added on all gutters.' },
+      { name: 'as-dragged', details: 'Added on gutter while dragged.' },
     ],
   }
 }


### PR DESCRIPTION
Fix #305: renamed classNames and components name
Changed `ui-` prefix to `as-` prefix