### PR TITLE
fix: spurious network call due to empty background image #316

### DIFF
--- a/projects/angular-split/src/lib/component/split.component.scss
+++ b/projects/angular-split/src/lib/component/split.component.scss
@@ -91,7 +91,7 @@
       cursor: default;
 
       .as-split-gutter-icon {
-        background-image: url('');
+        background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==');
       }
     }
   }


### PR DESCRIPTION
Adding a transparent 1x1 background image so that no spurious network call is shown. Particularly reproducible in electron env's.