### PR TITLE
feat: support angular compiler strict templates

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -25,7 +25,7 @@
             "assets": ["src/favicon.ico", "src/assets"],
             "styles": ["./node_modules/bootstrap/dist/css/bootstrap.min.css", "src/styles.scss"],
             "scripts": [],
-            "aot": false,
+            "aot": true,
             "vendorChunk": true,
             "extractLicenses": false,
             "buildOptimizer": false,
@@ -35,13 +35,7 @@
           },
           "configurations": {
             "production": {
-              "budgets": [
-                {
-                  "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
-                }
-              ],
+              "budgets": [],
               "outputHashing": "all"
             },
             "development": {

--- a/projects/angular-split/src/lib/directive/split-area.directive.ts
+++ b/projects/angular-split/src/lib/directive/split-area.directive.ts
@@ -2,6 +2,7 @@ import { Directive, ElementRef, Input, NgZone, OnDestroy, OnInit, Renderer2 } fr
 import { Subscription } from 'rxjs'
 import { SplitComponent } from '../component/split.component'
 import { getInputBoolean, getInputPositiveNumber } from '../utils'
+import { IAreaSize } from '../interface'
 
 @Directive({
   selector: 'as-split-area, [as-split-area]',
@@ -10,7 +11,7 @@ import { getInputBoolean, getInputPositiveNumber } from '../utils'
 export class SplitAreaDirective implements OnInit, OnDestroy {
   private _order: number | null = null
 
-  @Input() set order(v: number | null) {
+  @Input() set order(v: number | `${number}` | null | undefined) {
     this._order = getInputPositiveNumber(v, null)
 
     this.split.updateArea(this, true, false)
@@ -20,21 +21,21 @@ export class SplitAreaDirective implements OnInit, OnDestroy {
     return this._order
   }
 
-  private _size: number | null = null
+  private _size: IAreaSize = null
 
-  @Input() set size(v: number | null) {
-    this._size = getInputPositiveNumber(v, null)
+  @Input() set size(v: IAreaSize | `${number}` | null | undefined) {
+    this._size = getInputPositiveNumber(v, '*')
 
     this.split.updateArea(this, false, true)
   }
 
-  get size(): number | null {
+  get size(): IAreaSize {
     return this._size
   }
 
   private _minSize: number | null = null
 
-  @Input() set minSize(v: number | null) {
+  @Input() set minSize(v: number | `${number}` | null | undefined) {
     this._minSize = getInputPositiveNumber(v, null)
 
     this.split.updateArea(this, false, true)
@@ -46,7 +47,7 @@ export class SplitAreaDirective implements OnInit, OnDestroy {
 
   private _maxSize: number | null = null
 
-  @Input() set maxSize(v: number | null) {
+  @Input() set maxSize(v: number | `${number}` | null | undefined) {
     this._maxSize = getInputPositiveNumber(v, null)
 
     this.split.updateArea(this, false, true)
@@ -58,7 +59,7 @@ export class SplitAreaDirective implements OnInit, OnDestroy {
 
   private _lockSize = false
 
-  @Input() set lockSize(v: boolean) {
+  @Input() set lockSize(v: boolean | `${boolean}`) {
     this._lockSize = getInputBoolean(v)
 
     this.split.updateArea(this, false, true)
@@ -70,7 +71,7 @@ export class SplitAreaDirective implements OnInit, OnDestroy {
 
   private _visible = true
 
-  @Input() set visible(v: boolean) {
+  @Input() set visible(v: boolean | `${boolean}`) {
     this._visible = getInputBoolean(v)
 
     if (this._visible) {

--- a/projects/angular-split/src/lib/interface.ts
+++ b/projects/angular-split/src/lib/interface.ts
@@ -1,5 +1,13 @@
 import { SplitAreaDirective } from './directive/split-area.directive'
 
+export type ISplitDirection = 'horizontal' | 'vertical'
+
+export type ISplitDir = 'ltr' | 'rtl'
+
+export type IAreaSize = number | '*'
+
+export type ISplitUnit = 'percent' | 'pixel'
+
 export interface IPoint {
   x: number
   y: number
@@ -8,10 +16,10 @@ export interface IPoint {
 export interface IArea {
   component: SplitAreaDirective
   order: number
-  size: number | null
+  size: IAreaSize
   minSize: number | null
   maxSize: number | null
-  sizeBeforeCollapse: number | null
+  sizeBeforeCollapse: IAreaSize | null
   gutterBeforeCollapse: number
 }
 
@@ -29,7 +37,7 @@ export interface ISplitSnapshot {
 export interface IAreaSnapshot {
   area: IArea
   sizePixelAtStart: number
-  sizePercentAtStart: number
+  sizePercentAtStart: IAreaSize
 }
 
 // CREATED ON DRAG PROGRESS
@@ -42,19 +50,19 @@ export interface ISplitSideAbsorptionCapacity {
 export interface IAreaAbsorptionCapacity {
   areaSnapshot: IAreaSnapshot
   pixelAbsorb: number
-  percentAfterAbsorption: number
+  percentAfterAbsorption: IAreaSize
   pixelRemain: number
 }
 
 export interface IDefaultOptions {
-  dir: 'ltr' | 'rtl'
-  direction: 'horizontal' | 'vertical'
+  dir: ISplitDir
+  direction: ISplitDirection
   disabled: boolean
   gutterDblClickDuration: number
   gutterSize: number | null
   gutterStep: number
   restrictMove: boolean
-  unit: 'percent' | 'pixel'
+  unit: ISplitUnit
   useTransition: boolean
 }
 
@@ -65,4 +73,4 @@ export interface IOutputData {
   sizes: IOutputAreaSizes
 }
 
-export interface IOutputAreaSizes extends Array<number | '*'> {}
+export interface IOutputAreaSizes extends Array<IAreaSize> {}

--- a/src/app/examples/custom-gutter-style/custom-gutter-style.component.ts
+++ b/src/app/examples/custom-gutter-style/custom-gutter-style.component.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core'
-
 import { AComponent } from '../../ui/components/AComponent'
+import { ISplitDirection } from 'angular-split'
 
 @Component({
   selector: 'sp-ex-custom-gutter-style',
@@ -65,5 +65,5 @@ import { AComponent } from '../../ui/components/AComponent'
   `,
 })
 export class CustomGutterStyleComponent extends AComponent {
-  direction = 'horizontal'
+  direction: ISplitDirection = 'horizontal'
 }

--- a/src/app/examples/dir-rtl/dir-rtl.component.ts
+++ b/src/app/examples/dir-rtl/dir-rtl.component.ts
@@ -1,6 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core'
-
 import { AComponent } from '../../ui/components/AComponent'
+import { ISplitDir, ISplitDirection } from 'angular-split'
 
 @Component({
   selector: 'sp-ex-dir_rtl',
@@ -74,6 +74,6 @@ import { AComponent } from '../../ui/components/AComponent'
   `,
 })
 export class DirRtlComponent extends AComponent {
-  dir = 'rtl'
-  direction = 'horizontal'
+  dir: ISplitDir = 'rtl'
+  direction: ISplitDirection = 'horizontal'
 }

--- a/src/app/examples/geek-demo/geek-demo.component.ts
+++ b/src/app/examples/geek-demo/geek-demo.component.ts
@@ -1,7 +1,7 @@
 import { Component, ViewChild, ChangeDetectionStrategy } from '@angular/core'
 import { SortableComponent } from 'ngx-bootstrap/sortable'
-
 import { AComponent } from '../../ui/components/AComponent'
+import { IAreaSize, ISplitDirection } from 'angular-split'
 
 @Component({
   selector: 'sp-ex-geek-demo',
@@ -184,7 +184,16 @@ import { AComponent } from '../../ui/components/AComponent'
 export class GeekDemoComponent extends AComponent {
   @ViewChild(SortableComponent) sortableComponent: SortableComponent
 
-  d = {
+  d: {
+    dir: ISplitDirection
+    restrictMove: boolean
+    useTransition: boolean
+    gutterSize: number | null
+    gutterStep: number | null
+    width: number | null
+    height: number | null
+    areas: { id: number; color: string; size: IAreaSize; present: boolean; visible: boolean }[]
+  } = {
     dir: 'horizontal',
     restrictMove: true,
     useTransition: true,

--- a/src/app/examples/gutter-click-roll-unroll/gutter-click-roll-unroll.component.ts
+++ b/src/app/examples/gutter-click-roll-unroll/gutter-click-roll-unroll.component.ts
@@ -1,7 +1,6 @@
 import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core'
-import { SplitComponent } from 'angular-split'
+import { IAreaSize, IOutputAreaSizes, IOutputData, SplitComponent } from 'angular-split'
 import { Subscription } from 'rxjs'
-
 import { AComponent } from '../../ui/components/AComponent'
 import { formatDate } from '../../utils/format-date'
 
@@ -117,9 +116,9 @@ export class GutterClickRollUnrollComponent extends AComponent implements AfterV
   useTransition = true
   dblClickTime = 0
   logMessages: Array<{ type: string; text: string }> = []
-  areas = [
+  areas: { size: IAreaSize; order: number; content: string }[] = [
     { size: 25, order: 1, content: 'fg fdkjuh dfskhf dkujv fd vifdk hvdkuh fg' },
-    { size: 50, order: 2, content: 'sd h vdshhf deuyf gduyeg hudeg hudfg  fd vifdk hvdkuh fg' },
+    { size: '*', order: 2, content: 'sd h vdshhf deuyf gduyeg hudeg hudfg  fd vifdk hvdkuh fg' },
     { size: 25, order: 3, content: 'sd jslfd ijgil dfhlt jkgvbnhj fl bhjgflh jfglhj fl h fg' },
   ]
   sub: Subscription
@@ -138,7 +137,11 @@ export class GutterClickRollUnrollComponent extends AComponent implements AfterV
     })
   }
 
-  log(type: string, e: { gutterNum: number; sizes: Array<number> }) {
+  log(
+    ...[type, e]:
+      | [type: 'dragStart' | 'dragEnd' | 'gutterClick' | 'gutterDblClick', e: IOutputData]
+      | [type: 'transitionEnd', e: IOutputAreaSizes]
+  ) {
     this.logMessages.push({ type, text: `${formatDate(new Date())} > ${type} event > ${JSON.stringify(e)}` })
 
     setTimeout(() => {
@@ -156,29 +159,17 @@ export class GutterClickRollUnrollComponent extends AComponent implements AfterV
     }
   }
 
-  gutterClick(e: { gutterNum: number; sizes: Array<number> }) {
+  gutterClick(e: IOutputData) {
     if (e.gutterNum === 1) {
-      if (this.areas[0].size > 0) {
-        this.areas[1].size += this.areas[0].size
+      if ((this.areas[0].size as number) > 0) {
         this.areas[0].size = 0
-      } else if (this.areas[1].size > 25) {
-        this.areas[1].size -= 25
-        this.areas[0].size = 25
       } else {
         this.areas[0].size = 25
-        this.areas[1].size = 50
-        this.areas[2].size = 25
       }
     } else if (e.gutterNum === 2) {
-      if (this.areas[2].size > 0) {
-        this.areas[1].size += this.areas[2].size
+      if ((this.areas[2].size as number) > 0) {
         this.areas[2].size = 0
-      } else if (this.areas[1].size > 25) {
-        this.areas[1].size -= 25
-        this.areas[2].size = 25
       } else {
-        this.areas[0].size = 25
-        this.areas[1].size = 50
         this.areas[2].size = 25
       }
     }

--- a/src/app/examples/simple-split/simple-split.component.ts
+++ b/src/app/examples/simple-split/simple-split.component.ts
@@ -1,6 +1,5 @@
 import { Component, ChangeDetectionStrategy, ViewChild } from '@angular/core'
-import { SplitComponent, SplitAreaDirective } from 'angular-split'
-
+import { SplitComponent, SplitAreaDirective, ISplitDirection } from 'angular-split'
 import { AComponent } from '../../ui/components/AComponent'
 
 @Component({
@@ -169,7 +168,7 @@ export class SimpleSplitComponent extends AComponent {
   @ViewChild('area1') area1: SplitAreaDirective
   @ViewChild('area2') area2: SplitAreaDirective
 
-  direction = 'horizontal'
+  direction: ISplitDirection = 'horizontal'
   sizes = {
     percentWithoutWildcards: {
       area1: 30,

--- a/src/app/examples/split-transitions/split-transitions.component.ts
+++ b/src/app/examples/split-transitions/split-transitions.component.ts
@@ -1,7 +1,7 @@
 import { Component, ViewChild, ElementRef, ChangeDetectionStrategy } from '@angular/core'
-
 import { AComponent } from '../../ui/components/AComponent'
 import { formatDate } from '../../utils/format-date'
+import { IAreaSize } from 'angular-split'
 
 @Component({
   selector: 'sp-ex-transitions',
@@ -240,7 +240,15 @@ import { formatDate } from '../../utils/format-date'
   `,
 })
 export class SplitTransitionsComponent extends AComponent {
-  action = {
+  action: {
+    a1s: IAreaSize
+    a2s: IAreaSize
+    a3s: IAreaSize
+    a1v: boolean
+    a2v: boolean
+    a3v: boolean
+    useTransition: boolean
+  } = {
     a1s: 25,
     a2s: 50,
     a3s: 25,

--- a/src/app/examples/workspace-localstorage/workspace-localstorage.component.ts
+++ b/src/app/examples/workspace-localstorage/workspace-localstorage.component.ts
@@ -1,15 +1,15 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core'
 import { cloneDeep } from 'lodash'
-
 import { AComponent } from '../../ui/components/AComponent'
+import { IAreaSize, IOutputData } from 'angular-split'
 
 interface IConfig {
   columns: Array<{
     visible: boolean
-    size: number
+    size: IAreaSize
     rows: Array<{
       visible: boolean
-      size: number
+      size: IAreaSize
       type: string
     }>
   }>
@@ -147,7 +147,7 @@ export class WorkspaceLocalstorageComponent extends AComponent implements OnInit
     localStorage.removeItem(this.localStorageName)
   }
 
-  onDragEnd(columnindex: number, e: { gutterNum: number; sizes: Array<number> }) {
+  onDragEnd(columnindex: number, e: IOutputData) {
     // Column dragged
     if (columnindex === -1) {
       // Set size for all visible columns

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,8 @@
       "angular-split/*": ["dist/angular-split/*"]
     },
     "useDefineForClassFields": false
+  },
+  "angularCompilerOptions": {
+    "strictTemplates": true
   }
 }


### PR DESCRIPTION
Fix #220 

Features:
1. size is typed as `*` or `number`
2. `number` and `boolean` inputs support strings too (`prop="40"` and `prop="true"`)
3. New types: `ISplitDirection`, `ISplitDir`, `IAreaSize`, `ISplitUnit`
4. Fully compatible with strict templates considering all above too