### PR TITLE
chore: remove lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "core-js": "3.32.1",
     "husky": "^8.0.3",
     "lint-staged": "^14.0.1",
-    "lodash": "4.17.21",
     "marked": "7.0.4",
     "ngx-bootstrap": "11.0.2",
     "prettier": "^3.0.2",

--- a/src/app/examples/workspace-localstorage/workspace-localstorage.component.ts
+++ b/src/app/examples/workspace-localstorage/workspace-localstorage.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core'
-import { cloneDeep } from 'lodash'
 import { AComponent } from '../../ui/components/AComponent'
 import { IAreaSize, IOutputData } from 'angular-split'
 
@@ -142,7 +141,7 @@ export class WorkspaceLocalstorageComponent extends AComponent implements OnInit
   }
 
   resetConfig() {
-    this.config = cloneDeep(defaultConfig)
+    this.config = structuredClone(defaultConfig)
 
     localStorage.removeItem(this.localStorageName)
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6271,15 +6271,15 @@ lodash.once@^4.1.1:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash@4.17.21, lodash@^4.17.21, lodash@^4.7.0:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
 lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.21, lodash@^4.7.0:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
The demo app depended on `lodash` for `cloneDeep`, but we can use [structuredClone](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) which is supported in all major browsers.

It removes this warning:
> Warning: /Users/beeman/dev/github/angular-split/angular-split/src/app/examples/workspace-localstorage/workspace-localstorage.component.ts depends on 'lodash'. CommonJS or AMD dependencies can cause optimization bailouts.
