### PR TITLE
fix: change default area size from null to *

### DIFF
--- a/projects/angular-split/src/lib/directive/split-area.directive.ts
+++ b/projects/angular-split/src/lib/directive/split-area.directive.ts
@@ -21,7 +21,7 @@ export class SplitAreaDirective implements OnInit, OnDestroy {
     return this._order
   }
 
-  private _size: IAreaSize = null
+  private _size: IAreaSize = '*'
 
   @Input() set size(v: IAreaSize | `${number}` | null | undefined) {
     this._size = getInputPositiveNumber(v, '*')


### PR DESCRIPTION
Currently we don't support more than a single wildcard - but if no area size was provided or wrong area sizes the default logic in percent mode for example is splitting the size equally (kind of multiple wildcards).

This change make split areas without size work again even though this is invalid. The problem can be seen in the collapse example which has no tests coverage (another issue for another time).

We should think how to handle it - size required? Support multiple wildcards?