### PR TITLE
Documentation Update: Add Information About Input to Set Aria-Label for Gutter

### DIFF
--- a/src/app/documentation/documentation.component.ts
+++ b/src/app/documentation/documentation.component.ts
@@ -55,6 +55,12 @@ export class DocumentationComponent {
           'Disable the dragging feature (remove cursor/image on gutters). <code>(gutterClick)</code>/<code>(gutterDblClick)</code> still emits.',
       },
       {
+        name: 'gutterAriaLabel',
+        type: 'string',
+        default: 'null',
+        details: 'Aria label for the gutter.',
+      },
+      {
         name: 'gutterDblClickDuration',
         type: 'number',
         default: '0',


### PR DESCRIPTION
This PR aims update documentation by adding information about `gutterAriaLabel` input that enables setting an aria-label for the gutter.