### PR TITLE
fix: aria-valuenow incorrectly set to wildcard

### DIFF
--- a/projects/angular-split/src/lib/component/split.component.ts
+++ b/projects/angular-split/src/lib/component/split.component.ts
@@ -111,7 +111,7 @@ import { SplitGutterDirective } from '../gutter/split-gutter.directive'
         [attr.aria-orientation]="direction"
         [attr.aria-valuemin]="area.minSize"
         [attr.aria-valuemax]="area.maxSize"
-        [attr.aria-valuenow]="area.size"
+        [attr.aria-valuenow]="area.size === '*' ? null : area.size"
         [attr.aria-valuetext]="getAriaAreaSizeText(area.size)"
       >
         <ng-container *ngIf="customGutter?.template; else defaultGutterTpl">


### PR DESCRIPTION
Reverts aria-valuenow back to null instead of wildcard. Ideally should be the real value but it is a more involved change and it was never implemented this way to begin with.

Closes #362 