### PR TITLE
feat: add tabindex input and binding

### DIFF
--- a/projects/angular-split/src/lib/component/split.component.ts
+++ b/projects/angular-split/src/lib/component/split.component.ts
@@ -16,6 +16,7 @@ import {
   Inject,
   Optional,
   ContentChild,
+  numberAttribute,
 } from '@angular/core'
 import { Observable, Subscriber, Subject } from 'rxjs'
 import { debounceTime } from 'rxjs/operators'
@@ -95,7 +96,7 @@ import { SplitGutterDirective } from '../gutter/split-gutter.directive'
     >
       <div
         role="separator"
-        tabindex="0"
+        [tabindex]="tabindex"
         *ngIf="last === false"
         #gutterEls
         class="as-split-gutter"
@@ -156,6 +157,8 @@ export class SplitComponent implements AfterViewInit, OnDestroy {
   get direction(): ISplitDirection {
     return this._direction
   }
+
+  @Input({ transform: numberAttribute }) tabindex: number = 0
 
   @Input() set unit(v: ISplitUnit) {
     this._unit = v === 'pixel' ? 'pixel' : 'percent'


### PR DESCRIPTION
Adds tabindex Input for split component & defaults to previous fixed value of 0.

Closes https://github.com/angular-split/angular-split/issues/432