### PR TITLE
fix: handle TouchEvent in non touch capable devices for firefox

### DIFF
--- a/projects/angular-split/src/lib/utils.ts
+++ b/projects/angular-split/src/lib/utils.ts
@@ -10,7 +10,10 @@ export interface ClientPoint {
  * Only supporting a single {@link TouchEvent} point
  */
 export function getPointFromEvent(event: MouseEvent | TouchEvent | KeyboardEvent): ClientPoint {
-  if (event instanceof TouchEvent) {
+  // NOTE: In firefox TouchEvent is only defined for touch capable devices
+  const isTouchEvent = (e: typeof event): e is TouchEvent => window.TouchEvent && event instanceof TouchEvent
+
+  if (isTouchEvent(event)) {
     if (event.changedTouches.length === 0) {
       return undefined
     }


### PR DESCRIPTION
As firefox doesn't have `TouchEvent` defined for non touch capable devices another check is required.
Based on https://github.com/angular-split/angular-split/issues/441#issuecomment-2270716240 
Fixes #454 