### PR TITLE
fix: break circular reference between split and split-area

### DIFF
--- a/projects/angular-split/src/lib/split-area/split-area.component.ts
+++ b/projects/angular-split/src/lib/split-area/split-area.component.ts
@@ -9,7 +9,7 @@ import {
   input,
   isDevMode,
 } from '@angular/core'
-import { SplitComponent } from '../split/split.component'
+import { SPLIT_AREA_CONTRACT, SplitComponent } from '../split/split.component'
 import { createClassesString, mirrorSignal } from '../utils'
 import { SplitAreaSize, areaSizeTransform, boundaryAreaSizeTransform } from '../models'
 
@@ -19,6 +19,12 @@ import { SplitAreaSize, areaSizeTransform, boundaryAreaSizeTransform } from '../
   exportAs: 'asSplitArea',
   templateUrl: './split-area.component.html',
   styleUrl: './split-area.component.css',
+  providers: [
+    {
+      provide: SPLIT_AREA_CONTRACT,
+      useExisting: SplitAreaComponent,
+    },
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SplitAreaComponent {

--- a/projects/angular-split/src/lib/split/split.component.ts
+++ b/projects/angular-split/src/lib/split/split.component.ts
@@ -3,6 +3,7 @@ import {
   Component,
   ElementRef,
   HostBinding,
+  InjectionToken,
   NgZone,
   Renderer2,
   booleanAttribute,
@@ -17,7 +18,7 @@ import {
   untracked,
 } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
-import { SplitAreaComponent } from '../split-area/split-area.component'
+import type { SplitAreaComponent } from '../split-area/split-area.component'
 import { Subject, filter, fromEvent, map, pairwise, skipWhile, startWith, switchMap, take, takeUntil, tap } from 'rxjs'
 import {
   ClientPoint,
@@ -61,6 +62,8 @@ interface DragStartContext {
   areaAfterGutterIndex: number
 }
 
+export const SPLIT_AREA_CONTRACT = new InjectionToken<SplitAreaComponent>('Split Area Contract')
+
 @Component({
   selector: 'as-split',
   standalone: true,
@@ -83,7 +86,7 @@ export class SplitComponent {
   /**
    * @internal
    */
-  readonly _areas = contentChildren(SplitAreaComponent)
+  readonly _areas = contentChildren(SPLIT_AREA_CONTRACT)
   protected readonly customGutter = contentChild(SplitGutterDirective)
   readonly gutterSize = input(this.defaultOptions.gutterSize, {
     transform: numberAttributeWithFallback(this.defaultOptions.gutterSize),


### PR DESCRIPTION
When using jest for testing circular references are not allowed (while they are allowed for ng build and karma testing).
The origin of the circularity is `SplitComponent` referencing using `contentChildren` the `SplitAreaComponent` while `SplitAreaComponent` also injects `SplitComponent`.
To break the circular reference - an injection token is introduced to allow type only import of `SplitAreaComponent`.

Related to: https://github.com/angular-split/angular-split/issues/441#issuecomment-2311931230