### PR TITLE
refactor: drop signal writes effect

### DIFF
--- a/projects/angular-split/src/lib/split-area/split-area.component.ts
+++ b/projects/angular-split/src/lib/split-area/split-area.component.ts
@@ -47,9 +47,9 @@ export class SplitAreaComponent {
         return 0
       }
 
-      const size = this.size()
-      // auto acts the same as * in all calculations
-      return size === 'auto' ? '*' : size
+      const visibleIndex = this.split._visibleAreas().findIndex((area) => area === this)
+
+      return this.split._alignedVisibleAreasSizes()[visibleIndex]
     }),
   )
   /**

--- a/projects/angular-split/src/lib/utils.ts
+++ b/projects/angular-split/src/lib/utils.ts
@@ -131,3 +131,7 @@ export function leaveNgZone<T>() {
 }
 
 export const numberAttributeWithFallback = (fallback: number) => (value: unknown) => numberAttribute(value, fallback)
+
+export const assertUnreachable = (value: never, name: string) => {
+  throw new Error(`as-split: unknown value "${value}" for "${name}"`)
+}


### PR DESCRIPTION
Drop the validation effect that also updates internal sizes (with allow signal writes) and use computed instead as per the official angular recommendation.

The signal flow is now:
1. `SplitArea` has `visible` and `size`
2. `Split` creates `_visibleAreas` based on `SplitArea` `visible`
3. `Split` creates `_alignedVisibleAreasSizes` based on `_visibleAreas` and `SplitArea` `size` with validation alignments
4. `SplitArea` `_internalSize` is based on `_alignedVisibleAreasSizes`
5. `_internalSize` is the actual size anything else should use (except validations and normalizations)