### PR TITLE
fix: missing transition when hiding areas in pixel mode

### DIFF
--- a/projects/angular-split/src/lib/split/split.component.ts
+++ b/projects/angular-split/src/lib/split/split.component.ts
@@ -127,13 +127,13 @@ export class SplitComponent {
     let visitedVisibleAreas = 0
 
     this._areas().forEach((area, index, areas) => {
+      const unit = this.unit()
+      const areaSize = area._internalSize()
+
       // Add area size column
       if (!area.visible()) {
-        columns.push('0fr')
+        columns.push(unit === 'percent' || areaSize === '*' ? '0fr' : '0px')
       } else {
-        const areaSize = area._internalSize()
-        const unit = this.unit()
-
         if (unit === 'pixel') {
           const columnValue = areaSize === '*' ? '1fr' : `${areaSize}px`
           columns.push(columnValue)


### PR DESCRIPTION
Grid columns transitions requires the same unit in order to work. This PR changes non wildcard hidden areas to 0px in pixel mode for transitions to work correctly.
There is still a transition bug when changing from `px` to `fr` or vice versa - but I don't have a good solution for it currently.