### PR TITLE
fix: disabled split gutter interactions

### DIFF
--- a/projects/angular-split/src/lib/split/split.component.ts
+++ b/projects/angular-split/src/lib/split/split.component.ts
@@ -254,12 +254,12 @@ export class SplitComponent {
     areaBeforeGutterIndex: number,
     areaAfterGutterIndex: number,
   ) {
+    e.preventDefault()
+    e.stopPropagation()
+
     if (this.disabled()) {
       return
     }
-
-    e.preventDefault()
-    e.stopPropagation()
 
     this.gutterMouseDownSubject.next({
       mouseDownEvent: e,


### PR DESCRIPTION
Chrome fires both `mousedown` and `touchstart` events. When split is disabled there was no prevent default which resulted in two click events firing. This means that clicking on a disabled gutter and changing size will not work (see https://angular-split.github.io/examples/gutter-click-roll-unroll in mobile mode using chrome devtools and clicking the gutter)