### PR TITLE
feat: make size a `model`

### DIFF
--- a/projects/angular-split/src/lib/models.ts
+++ b/projects/angular-split/src/lib/models.ts
@@ -5,8 +5,7 @@ export type SplitAreaSizeInput = SplitAreaSize | `${number}` | undefined | null
 const internalAreaSizeTransform = (areaSize: SplitAreaSizeInput): SplitAreaSize =>
   areaSize === undefined || areaSize === null || areaSize === '*' ? '*' : +areaSize
 
-export const areaSizeTransform = (areaSize: SplitAreaSizeInput): SplitAreaSize | 'auto' =>
-  internalAreaSizeTransform(areaSize)
+export const areaSizeTransform = (areaSize: SplitAreaSizeInput): SplitAreaSize => internalAreaSizeTransform(areaSize)
 
 export const boundaryAreaSizeTransform = (areaSize: SplitAreaSizeInput): SplitAreaSize =>
   internalAreaSizeTransform(areaSize)

--- a/projects/angular-split/src/lib/validations.ts
+++ b/projects/angular-split/src/lib/validations.ts
@@ -7,10 +7,7 @@ export function areAreasValid(areas: readonly SplitAreaComponent[], unit: SplitU
     return true
   }
 
-  const areaSizes = areas.map((area): SplitAreaSize => {
-    const size = area.size()
-    return size === 'auto' ? '*' : size
-  })
+  const areaSizes = areas.map((area): SplitAreaSize => area._normalizedSize())
 
   const wildcardAreas = areaSizes.filter((areaSize) => areaSize === '*')
 


### PR DESCRIPTION
I observed that `internalAreaSizeTransform` will never let `'auto'`, it would get parsed to a number, thus ending as `NaN`. Therefore I removed all references to `'auto'` and replaced them with `'*'` where appropriate.

I migrated the `size` input to `model`, allowing for safe external code interaction.

Left a comment about an idea of stopping drag when page is blured (when a tab is changed or similar cations, as it might cause interesting behaviours; ex.: User starts dragging, tabs out, let go of mouse, goes back in, and the drag is never cancelled, but a new one can be started)