### PR TITLE
fix: use afterRender and host

### DIFF
--- a/projects/angular-split/src/lib/split/split.component.ts
+++ b/projects/angular-split/src/lib/split/split.component.ts
@@ -165,13 +165,15 @@ export class SplitComponent {
   constructor() {
     if (isDevMode()) {
       // Logs warnings to console when the provided areas sizes are invalid
-      afterRenderEffect(() => {
-        // Special mode when no size input was declared which is a valid mode
-        if (this.unit() === 'percent' && this._visibleAreas().every((area) => area.size() === 'auto')) {
-          return
-        }
+      afterRenderEffect({
+        read: () => {
+          // Special mode when no size input was declared which is a valid mode
+          if (this.unit() === 'percent' && this._visibleAreas().every((area) => area.size() === 'auto')) {
+            return
+          }
 
-        areAreasValid(this._visibleAreas(), this.unit(), true)
+          areAreasValid(this._visibleAreas(), this.unit(), true)
+        },
       })
     }
 

--- a/projects/angular-split/src/lib/split/split.component.ts
+++ b/projects/angular-split/src/lib/split/split.component.ts
@@ -84,9 +84,6 @@ export const SPLIT_AREA_CONTRACT = new InjectionToken<SplitAreaComponent>('Split
   templateUrl: './split.component.html',
   styleUrl: './split.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  // host: {
-  //   '[style.gridTemplate]': 'gridTemplateColumnsStyle()',
-  // },
 })
 export class SplitComponent {
   private readonly document = inject(DOCUMENT)

--- a/projects/angular-split/src/lib/split/split.component.ts
+++ b/projects/angular-split/src/lib/split/split.component.ts
@@ -177,10 +177,12 @@ export class SplitComponent {
       })
     }
 
+    // we are running this after Angular has completed its CD loop
+    // as we are updating the style of the host, and we don't want to re-trigger the CD loop
+    // doing this in the host of the component would retrigger the CD too many times
     afterRenderEffect({
       read: () => {
-        const gridTemplate = this.gridTemplateColumnsStyle()
-        this.elementRef.nativeElement.style.gridTemplate = gridTemplate
+        this.elementRef.nativeElement.style.gridTemplate = this.gridTemplateColumnsStyle()
       },
     })
 

--- a/projects/angular-split/src/lib/split/split.component.ts
+++ b/projects/angular-split/src/lib/split/split.component.ts
@@ -1,3 +1,4 @@
+import { DOCUMENT, NgStyle, NgTemplateOutlet } from '@angular/common'
 import {
   ChangeDetectionStrategy,
   Component,
@@ -5,12 +6,11 @@ import {
   HostBinding,
   InjectionToken,
   NgZone,
-  Renderer2,
+  afterRenderEffect,
   booleanAttribute,
   computed,
   contentChild,
   contentChildren,
-  effect,
   inject,
   input,
   isDevMode,
@@ -18,7 +18,6 @@ import {
   signal,
 } from '@angular/core'
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop'
-import type { SplitAreaComponent } from '../split-area/split-area.component'
 import {
   Subject,
   filter,
@@ -33,26 +32,26 @@ import {
   takeUntil,
   tap,
 } from 'rxjs'
+import { ANGULAR_SPLIT_DEFAULT_OPTIONS } from '../angular-split-config.token'
+import { SplitGutterDynamicInjectorDirective } from '../gutter/split-gutter-dynamic-injector.directive'
+import { SplitGutterDirective } from '../gutter/split-gutter.directive'
+import { SplitAreaSize, SplitGutterInteractionEvent } from '../models'
+import type { SplitAreaComponent } from '../split-area/split-area.component'
+import { SplitCustomEventsBehaviorDirective } from '../split-custom-events-behavior.directive'
 import {
   ClientPoint,
+  assertUnreachable,
   createClassesString,
-  gutterEventsEqualWithDelta,
   fromMouseMoveEvent,
   fromMouseUpEvent,
   getPointFromEvent,
+  gutterEventsEqualWithDelta,
   leaveNgZone,
   numberAttributeWithFallback,
   sum,
   toRecord,
-  assertUnreachable,
 } from '../utils'
-import { DOCUMENT, NgStyle, NgTemplateOutlet } from '@angular/common'
-import { SplitGutterInteractionEvent, SplitAreaSize } from '../models'
-import { SplitCustomEventsBehaviorDirective } from '../split-custom-events-behavior.directive'
 import { areAreasValid } from '../validations'
-import { SplitGutterDirective } from '../gutter/split-gutter.directive'
-import { SplitGutterDynamicInjectorDirective } from '../gutter/split-gutter-dynamic-injector.directive'
-import { ANGULAR_SPLIT_DEFAULT_OPTIONS } from '../angular-split-config.token'
 
 interface MouseDownContext {
   mouseDownEvent: MouseEvent | TouchEvent
@@ -85,10 +84,12 @@ export const SPLIT_AREA_CONTRACT = new InjectionToken<SplitAreaComponent>('Split
   templateUrl: './split.component.html',
   styleUrl: './split.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[style.gridTemplate]': 'gridTemplateColumnsStyle()',
+  },
 })
 export class SplitComponent {
   private readonly document = inject(DOCUMENT)
-  private readonly renderer = inject(Renderer2)
   private readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef)
   private readonly ngZone = inject(NgZone)
   private readonly defaultOptions = inject(ANGULAR_SPLIT_DEFAULT_OPTIONS)
@@ -164,7 +165,7 @@ export class SplitComponent {
   constructor() {
     if (isDevMode()) {
       // Logs warnings to console when the provided areas sizes are invalid
-      effect(() => {
+      afterRenderEffect(() => {
         // Special mode when no size input was declared which is a valid mode
         if (this.unit() === 'percent' && this._visibleAreas().every((area) => area.size() === 'auto')) {
           return
@@ -173,14 +174,6 @@ export class SplitComponent {
         areAreasValid(this._visibleAreas(), this.unit(), true)
       })
     }
-
-    // Responsible for updating grid template style. Must be this way and not based on HostBinding
-    // as change detection for host binding is bound to the parent component and this style
-    // is updated on every mouse move. Doing it this way will prevent change detection cycles in parent.
-    effect(() => {
-      const gridTemplateColumnsStyle = this.gridTemplateColumnsStyle()
-      this.renderer.setStyle(this.elementRef.nativeElement, 'grid-template', gridTemplateColumnsStyle)
-    })
 
     this.gutterMouseDownSubject
       .pipe(

--- a/projects/angular-split/src/lib/split/split.component.ts
+++ b/projects/angular-split/src/lib/split/split.component.ts
@@ -84,9 +84,9 @@ export const SPLIT_AREA_CONTRACT = new InjectionToken<SplitAreaComponent>('Split
   templateUrl: './split.component.html',
   styleUrl: './split.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  host: {
-    '[style.gridTemplate]': 'gridTemplateColumnsStyle()',
-  },
+  // host: {
+  //   '[style.gridTemplate]': 'gridTemplateColumnsStyle()',
+  // },
 })
 export class SplitComponent {
   private readonly document = inject(DOCUMENT)
@@ -176,6 +176,13 @@ export class SplitComponent {
         },
       })
     }
+
+    afterRenderEffect({
+      read: () => {
+        const gridTemplate = this.gridTemplateColumnsStyle()
+        this.elementRef.nativeElement.style.gridTemplate = gridTemplate
+      },
+    })
 
     this.gutterMouseDownSubject
       .pipe(

--- a/projects/angular-split/src/lib/split/split.component.ts
+++ b/projects/angular-split/src/lib/split/split.component.ts
@@ -166,6 +166,9 @@ export class SplitComponent {
     if (isDevMode()) {
       // Logs warnings to console when the provided areas sizes are invalid
       afterRenderEffect({
+        // we use the afterRender read phase here,
+        //  because we want to run this after all processing is done.
+        //  and we are not updating anything in the DOM
         read: () => {
           // Special mode when no size input was declared which is a valid mode
           if (this.unit() === 'percent' && this._visibleAreas().every((area) => area.size() === 'auto')) {
@@ -181,7 +184,7 @@ export class SplitComponent {
     // as we are updating the style of the host, and we don't want to re-trigger the CD loop
     // doing this in the host of the component would retrigger the CD too many times
     afterRenderEffect({
-      read: () => {
+      write: () => {
         this.elementRef.nativeElement.style.gridTemplate = this.gridTemplateColumnsStyle()
       },
     })

--- a/src/app/examples/split-transitions/split-transitions.component.ts
+++ b/src/app/examples/split-transitions/split-transitions.component.ts
@@ -267,7 +267,7 @@ export class SplitTransitionsComponent extends AComponent {
     setTimeout(() => {
       const logsEl = this.logsEl()
       if (logsEl.nativeElement.scroll) {
-        ;(<HTMLElement>logsEl.nativeElement).scroll({ top: this.logMessages.length * 30 })
+        (<HTMLElement>logsEl.nativeElement).scroll({ top: this.logMessages.length * 30 })
       }
     })
   }


### PR DESCRIPTION
@Harpush  @Jefiozie 
I moved the effect to afterrendereffect, and moved the other effect into 'host' 

With this change, we no longer need to use `renderer2` in the component.  Also, AFAIK, there is no change in the CD of the parent component.  Using the computed value ensures that the thing is debounced as accurately as possible.

I'm not 100% sure about this thing tho, so please review carefully

should closes #513 