### PR TITLE
fix: gutter content child without descendants

### DIFF
--- a/projects/angular-split/src/lib/split/split.component.ts
+++ b/projects/angular-split/src/lib/split/split.component.ts
@@ -98,7 +98,7 @@ export class SplitComponent {
    * @internal
    */
   readonly _areas = contentChildren(SPLIT_AREA_CONTRACT)
-  protected readonly customGutter = contentChild(SplitGutterDirective)
+  protected readonly customGutter = contentChild(SplitGutterDirective, { descendants: false })
   readonly gutterSize = input(this.defaultOptions.gutterSize, {
     transform: numberAttributeWithFallback(this.defaultOptions.gutterSize),
   })


### PR DESCRIPTION
`contentChild` default behavior is to match descendants. For the gutter it means in nested splits the top split would get the same gutter defined in the inner split which I think is unexpected.

@SanderElias @Jefiozie Do you see any reason we might want descendants matching for the gutter directive?

Closes #517 
